### PR TITLE
Implement auto-approval for planned leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Schedule-first
+
+Prototype repository for scheduler logic experiments.
+
+## Features
+
+- `autoApproveLeave` function to approve planned leave when coverage is not impacted.

--- a/src/autoApproveLeave.js
+++ b/src/autoApproveLeave.js
@@ -1,0 +1,70 @@
+const MS_PER_MINUTE = 60 * 1000;
+const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE;
+
+function startOfDay(date, tz) {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+  const parts = fmt.formatToParts(date);
+  const y = parts.find(p => p.type === 'year').value;
+  const m = parts.find(p => p.type === 'month').value;
+  const d = parts.find(p => p.type === 'day').value;
+  return new Date(`${y}-${m}-${d}T00:00:00.000Z`);
+}
+
+function daysBetweenLocal(a, b, tz) {
+  const startA = startOfDay(a, tz);
+  const startB = startOfDay(b, tz);
+  return Math.floor((startB.getTime() - startA.getTime()) / MS_PER_DAY);
+}
+
+function expandIntervals(assignments, windowStart, windowEnd, tz, intervalMinutes = 30) {
+  const intervals = [];
+  for (const a of assignments) {
+    const start = Math.max(a.start.getTime(), windowStart.getTime());
+    const end = Math.min(a.end.getTime(), windowEnd.getTime());
+    if (start >= end) continue;
+    let cursor = start;
+    while (cursor < end) {
+      const time = new Intl.DateTimeFormat('en-GB', {
+        timeZone: tz,
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      }).format(new Date(cursor));
+      intervals.push({
+        channel: a.channel,
+        time,
+        counted: a.counted !== false
+      });
+      cursor += intervalMinutes * MS_PER_MINUTE;
+    }
+  }
+  return intervals;
+}
+
+function canAutoApproveLeave(ctx) {
+  const { site, request, assignments, coverage } = ctx;
+  const leadTimeDays = daysBetweenLocal(request.createdAt, request.start, site.tz);
+  if (leadTimeDays < site.leaveAutoApproveDays) return false;
+  const intervals = expandIntervals(assignments, request.start, request.end, site.tz);
+  for (const i of intervals) {
+    const info = (coverage[i.channel] && coverage[i.channel][i.time]) || { staffed: 0, target: 0 };
+    const staffed = info.staffed - (i.counted ? 1 : 0);
+    const delta = staffed - info.target;
+    if (delta < -site.leaveAutoApproveMaxDeficit) return false;
+  }
+  return true;
+}
+
+function autoApproveLeave(ctx) {
+  if (!canAutoApproveLeave(ctx)) return false;
+  ctx.request.status = 'APPROVED';
+  ctx.request.approvedAt = new Date();
+  return true;
+}
+
+module.exports = { autoApproveLeave, canAutoApproveLeave };

--- a/test/autoApproveLeave.test.js
+++ b/test/autoApproveLeave.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+const { autoApproveLeave } = require('../src/autoApproveLeave');
+
+function d(str) { return new Date(str + 'Z'); }
+
+// Setup common site settings
+const site = {
+  tz: 'Europe/London',
+  leaveAutoApproveDays: 2,
+  leaveAutoApproveMaxDeficit: 0
+};
+
+
+// Test: auto approve when no coverage deficit
+(function testApprove() {
+  const request = { createdAt: d('2023-01-01T00:00'), start: d('2023-01-05T10:00'), end: d('2023-01-05T12:00'), status: 'PENDING' };
+  const assignments = [{ start: d('2023-01-05T10:00'), end: d('2023-01-05T12:00'), channel: 'Phone', counted: true }];
+  const coverage = { Phone: { '10:00': { staffed: 3, target: 2 }, '10:30': { staffed: 3, target: 2 }, '11:00': { staffed: 3, target: 2 }, '11:30': { staffed: 3, target: 2 } } };
+  const ctx = { site, request, assignments, coverage };
+  const res = autoApproveLeave(ctx);
+  assert.strictEqual(res, true);
+  assert.strictEqual(request.status, 'APPROVED');
+})();
+
+// Test: reject when coverage deficit would occur
+(function testRejectDeficit() {
+  const request = { createdAt: d('2023-01-01T00:00'), start: d('2023-01-05T10:00'), end: d('2023-01-05T12:00'), status: 'PENDING' };
+  const assignments = [{ start: d('2023-01-05T10:00'), end: d('2023-01-05T12:00'), channel: 'Phone', counted: true }];
+  const coverage = { Phone: { '10:00': { staffed: 2, target: 2 }, '10:30': { staffed: 2, target: 2 }, '11:00': { staffed: 2, target: 2 }, '11:30': { staffed: 2, target: 2 } } };
+  const ctx = { site, request, assignments, coverage };
+  const res = autoApproveLeave(ctx);
+  assert.strictEqual(res, false);
+  assert.strictEqual(request.status, 'PENDING');
+})();
+
+// Test: reject when lead time too short
+(function testRejectLeadTime() {
+  const request = { createdAt: d('2023-01-01T00:00'), start: d('2023-01-02T10:00'), end: d('2023-01-02T12:00'), status: 'PENDING' };
+  const assignments = [{ start: d('2023-01-02T10:00'), end: d('2023-01-02T12:00'), channel: 'Phone', counted: true }];
+  const coverage = { Phone: { '10:00': { staffed: 3, target: 2 }, '10:30': { staffed: 3, target: 2 }, '11:00': { staffed: 3, target: 2 }, '11:30': { staffed: 3, target: 2 } } };
+  const ctx = { site, request, assignments, coverage };
+  const res = autoApproveLeave(ctx);
+  assert.strictEqual(res, false);
+  assert.strictEqual(request.status, 'PENDING');
+})();
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add `autoApproveLeave` to approve planned leave when coverage deficits are avoided
- include tests ensuring approval and rejection logic
- document new utility in README

## Testing
- `node test/autoApproveLeave.test.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a085af3ff48321a1dbe60973aeda8d