### PR TITLE
Implement auto-approval for planned leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Schedule-first
+
+Prototype repository for scheduler logic experiments.
+
+## Features
+
+- `autoApproveLeave` function to approve planned leave when coverage is not impacted.
+
+## Development
+
+- Run the unit tests with `npm test`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "schedule-first",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/autoApproveLeave.test.js"
+  }
+}

--- a/src/autoApproveLeave.js
+++ b/src/autoApproveLeave.js
@@ -1,0 +1,65 @@
+const MS_PER_MINUTE = 60 * 1000;
+const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE;
+
+function localDateString(date, tz) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).format(date);
+}
+
+function daysBetweenLocal(a, b, tz) {
+  const startA = Date.parse(localDateString(a, tz));
+  const startB = Date.parse(localDateString(b, tz));
+  return Math.floor((startB - startA) / MS_PER_DAY);
+}
+
+function expandIntervals(assignments, windowStart, windowEnd, tz, intervalMinutes = 30) {
+  const intervals = [];
+  for (const a of assignments) {
+    const start = Math.max(a.start.getTime(), windowStart.getTime());
+    const end = Math.min(a.end.getTime(), windowEnd.getTime());
+    if (start >= end) continue;
+    let cursor = start;
+    while (cursor < end) {
+      const time = new Intl.DateTimeFormat('en-GB', {
+        timeZone: tz,
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      }).format(new Date(cursor));
+      intervals.push({
+        channel: a.channel,
+        time,
+        counted: a.counted !== false
+      });
+      cursor += intervalMinutes * MS_PER_MINUTE;
+    }
+  }
+  return intervals;
+}
+
+function canAutoApproveLeave(ctx) {
+  const { site, request, assignments, coverage } = ctx;
+  const leadTimeDays = daysBetweenLocal(request.createdAt, request.start, site.tz);
+  if (leadTimeDays < site.leaveAutoApproveDays) return false;
+  const intervals = expandIntervals(assignments, request.start, request.end, site.tz);
+  for (const i of intervals) {
+    const info = (coverage[i.channel] && coverage[i.channel][i.time]) || { staffed: 0, target: 0 };
+    const staffed = info.staffed - (i.counted ? 1 : 0);
+    const delta = staffed - info.target;
+    if (delta < -site.leaveAutoApproveMaxDeficit) return false;
+  }
+  return true;
+}
+
+function autoApproveLeave(ctx) {
+  if (!canAutoApproveLeave(ctx)) return false;
+  ctx.request.status = 'APPROVED';
+  ctx.request.approvedAt = new Date();
+  return true;
+}
+
+module.exports = { autoApproveLeave, canAutoApproveLeave };

--- a/test/autoApproveLeave.test.js
+++ b/test/autoApproveLeave.test.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const { autoApproveLeave } = require('../src/autoApproveLeave');
+
+function d(str) { return new Date(str + 'Z'); }
+
+// Setup common site settings
+const site = {
+  tz: 'Europe/London',
+  leaveAutoApproveDays: 2,
+  leaveAutoApproveMaxDeficit: 0
+};
+
+
+// Test: auto approve when no coverage deficit
+(function testApprove() {
+  const request = { createdAt: d('2023-01-01T00:00'), start: d('2023-01-05T10:00'), end: d('2023-01-05T12:00'), status: 'PENDING' };
+  const assignments = [{ start: d('2023-01-05T10:00'), end: d('2023-01-05T12:00'), channel: 'Phone', counted: true }];
+  const coverage = { Phone: { '10:00': { staffed: 3, target: 2 }, '10:30': { staffed: 3, target: 2 }, '11:00': { staffed: 3, target: 2 }, '11:30': { staffed: 3, target: 2 } } };
+  const ctx = { site, request, assignments, coverage };
+  const res = autoApproveLeave(ctx);
+  assert.strictEqual(res, true);
+  assert.strictEqual(request.status, 'APPROVED');
+})();
+
+// Test: reject when coverage deficit would occur
+(function testRejectDeficit() {
+  const request = { createdAt: d('2023-01-01T00:00'), start: d('2023-01-05T10:00'), end: d('2023-01-05T12:00'), status: 'PENDING' };
+  const assignments = [{ start: d('2023-01-05T10:00'), end: d('2023-01-05T12:00'), channel: 'Phone', counted: true }];
+  const coverage = { Phone: { '10:00': { staffed: 2, target: 2 }, '10:30': { staffed: 2, target: 2 }, '11:00': { staffed: 2, target: 2 }, '11:30': { staffed: 2, target: 2 } } };
+  const ctx = { site, request, assignments, coverage };
+  const res = autoApproveLeave(ctx);
+  assert.strictEqual(res, false);
+  assert.strictEqual(request.status, 'PENDING');
+})();
+
+// Test: reject when lead time too short
+(function testRejectLeadTime() {
+  const request = { createdAt: d('2023-01-01T00:00'), start: d('2023-01-02T10:00'), end: d('2023-01-02T12:00'), status: 'PENDING' };
+  const assignments = [{ start: d('2023-01-02T10:00'), end: d('2023-01-02T12:00'), channel: 'Phone', counted: true }];
+  const coverage = { Phone: { '10:00': { staffed: 3, target: 2 }, '10:30': { staffed: 3, target: 2 }, '11:00': { staffed: 3, target: 2 }, '11:30': { staffed: 3, target: 2 } } };
+  const ctx = { site, request, assignments, coverage };
+  const res = autoApproveLeave(ctx);
+  assert.strictEqual(res, false);
+  assert.strictEqual(request.status, 'PENDING');
+})();
+
+// Test: lead time uses site timezone
+(function testLeadTimeTimezone() {
+  const siteKL = { ...site, tz: 'Asia/Kuala_Lumpur', leaveAutoApproveDays: 1 };
+  const request = {
+    createdAt: d('2023-01-01T18:00'), // 02:00 local Jan 2
+    start: d('2023-01-02T16:00'),     // 00:00 local Jan 3
+    end: d('2023-01-02T18:00'),
+    status: 'PENDING'
+  };
+  const assignments = [{ start: d('2023-01-02T16:00'), end: d('2023-01-02T18:00'), channel: 'Phone', counted: true }];
+  const coverage = { Phone: { '00:00': { staffed: 3, target: 2 }, '00:30': { staffed: 3, target: 2 }, '01:00': { staffed: 3, target: 2 }, '01:30': { staffed: 3, target: 2 } } };
+  const ctx = { site: siteKL, request, assignments, coverage };
+  const res = autoApproveLeave(ctx);
+  assert.strictEqual(res, true);
+  assert.strictEqual(request.status, 'APPROVED');
+})();
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- compute lead time using site-local dates for planned leave auto approval
- add npm test script and development docs
- extend tests for timezone lead-time scenario

## Testing
- `node test/autoApproveLeave.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a085af3ff48321a1dbe60973aeda8d